### PR TITLE
Add ->decoded_content and a few utility methods.

### DIFF
--- a/lib/HTTP/Tiny/UA/Response.pm
+++ b/lib/HTTP/Tiny/UA/Response.pm
@@ -7,6 +7,7 @@ package HTTP::Tiny::UA::Response;
 # VERSION
 
 use Class::Tiny qw( success url status reason content headers protocol );
+use Encode qw();
 
 =attr success
 
@@ -35,6 +36,81 @@ Otherwise it will be a scalar value.
 sub header {
     my ( $self, $field ) = @_;
     return $self->headers->{ lc $field };
+}
+
+=method content_type
+
+Returns the L<< C<type/subtype>|http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.7 >> portion of the C<content-type> header.
+
+Returns C<undef> if there was no C<content-type> header.
+
+    if ( $result->content_type eq 'application/json' ) {
+        ...
+    }
+
+=cut
+
+sub content_type {
+    my ($self) = @_;
+    return unless exists $self->headers->{'content-type'};
+    return
+      unless my ($type) =
+      $self->headers->{'content-type'} =~ qr{ \A ( [^/]+ / [^;]+ ) }msx;
+    return $type;
+}
+
+=method content_type_params
+
+Returns all L<< C<parameter>|http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.7 >> parts of the C<content-type> header
+as an C<ArrayRef>.
+
+Returns an empty C<ArrayRef> if no such parameters were sent in the C<content-type> header, or there was no C<content-type> header.
+
+    for my $header ( @{ $result->content_type_params } ) {
+        if ( $header =~ /^charset=(.+)/ ) {
+            print "A charset of $1 was specified! :D";
+        }
+    }
+
+=cut
+
+sub content_type_params {
+    my ($self) = @_;
+    return [] unless exists $self->headers->{'content-type'};
+    return []
+      unless my (@params) = $self->headers->{'content-type'} =~ qr{ (?:;([^;]+))+ }msx;
+    return [@params];
+}
+
+=method decoded_content
+
+Returns L<< C<< ->content >>|/content >> after applying type specific decoding.
+
+At present, this means everything that is not C<text/*> will simply yield C<< ->content >>
+
+And everything that is C<text/*> without a C<text/*;charset=someencoding> will simply yield C<< ->content >>
+
+    my $foo = $result->decoded_content(); # text/* with a specified encoding interpreted properly.
+
+Optionally, you can pass a forced encoding to apply and override smart detection.
+
+    my $foo = $result->decoded_content('utf-8'); # type specific encodings ignored, utf-8 forced.
+
+=cut
+
+sub decoded_content {
+    my ( $self, $force_encoding ) = @_;
+    if ( not $force_encoding ) {
+        return $self->content if not my $type = $self->content_type;
+        return $self->content unless $type =~ qr{ \Atext/ }msx;
+        for my $param ( @{ $self->content_type_params } ) {
+            if ( $param =~ qr{ \Acharset=(.+)\z }msx ) {
+                $force_encoding = $param;
+            }
+        }
+        return $self->content if not $force_encoding;
+    }
+    return Encode::decode( $force_encoding, $self->content, Encode::FB_CROAK );
 }
 
 1;

--- a/t/300_decode_content.t
+++ b/t/300_decode_content.t
@@ -1,0 +1,92 @@
+use strict;
+use warnings;
+
+use Test::More;
+
+# ABSTRACT: Simulate decoding content
+
+use HTTP::Tiny::UA::Response;
+use Test::Fatal qw( exception );
+
+my $utf8_string = "\x{100}\x{2192}\x{2193}";
+utf8::encode( my $encoded_string = $utf8_string );
+
+isnt( $utf8_string, $encoded_string,
+    "Character String and Byte String should be different" );
+
+can_ok( 'HTTP::Tiny::UA::Response',
+    qw( content decoded_content content_type content_type_params) );
+
+subtest 'No Hints' => sub {
+    my $response = HTTP::Tiny::UA::Response->new(
+        success  => 1,
+        protocol => 'HTTP/1.1',
+        status   => 200,
+        url      => 'synthetic://HTTP.Tiny.UA/300_decode_content.t',
+        content  => $encoded_string,
+        headers  => {},
+    );
+    my $e;
+    is(
+        $e = exception {
+            is( $response->content, $encoded_string, 'content is not decoded' );
+            is( $response->decoded_content,
+                $encoded_string, 'encoded_content is same as content here' );
+            is( $response->content_type, undef, 'no content type available' );
+            is_deeply( $response->content_type_params, [], 'no content type params' );
+        },
+        undef,
+        'All expected methods defined and not throwing exceptions'
+    ) or diag $e ;
+};
+
+subtest 'simple text/plain, No Hints' => sub {
+    my $response = HTTP::Tiny::UA::Response->new(
+        success  => 1,
+        protocol => 'HTTP/1.1',
+        status   => 200,
+        url      => 'synthetic://HTTP.Tiny.UA/300_decode_content.t',
+        content  => $encoded_string,
+        headers  => { 'content-type' => 'text/plain', }
+    );
+    my $e;
+    is(
+        $e = exception {
+
+            is( $response->content, $encoded_string, 'content is not decoded' );
+            is( $response->decoded_content,
+                $encoded_string, 'encoded_content is  the same as content here' );
+            is( $response->content_type, 'text/plain', 'content type is text/plain' );
+            is_deeply( $response->content_type_params, [], 'no content type params' );
+
+        },
+        undef,
+        'All expected methods defined and not throwing exceptions'
+    ) or diag $e;
+};
+
+subtest 'text/plain;charset=utf-8' => sub {
+    my $response = HTTP::Tiny::UA::Response->new(
+        success  => 1,
+        protocol => 'HTTP/1.1',
+        status   => 200,
+        url      => 'synthetic://HTTP.Tiny.UA/300_decode_content.t',
+        content  => $encoded_string,
+        headers  => { 'content-type' => 'text/plain;charset=utf-8', },
+    );
+    my $e;
+    is(
+        $e = exception {
+            is( $response->content,         $encoded_string, 'content is not decoded' );
+            is( $response->decoded_content, $utf8_string,    'encoded_content decoded as utf8' );
+            is( $response->content_type,    'text/plain',    'content type is text/plain' );
+            is_deeply( $response->content_type_params,
+                ['charset=utf-8'], 'content type params says charset=utf8' );
+        },
+        undef,
+        'All expected methods defined and not throwing exceptions'
+    ) or diag $e;
+};
+
+done_testing;
+

--- a/t/300_decode_content.t
+++ b/t/300_decode_content.t
@@ -17,75 +17,315 @@ isnt( $utf8_string, $encoded_string,
 can_ok( 'HTTP::Tiny::UA::Response',
     qw( content decoded_content content_type content_type_params) );
 
-subtest 'No Hints' => sub {
-    my $response = HTTP::Tiny::UA::Response->new(
-        success  => 1,
-        protocol => 'HTTP/1.1',
-        status   => 200,
-        url      => 'synthetic://HTTP.Tiny.UA/300_decode_content.t',
-        content  => $encoded_string,
-        headers  => {},
-    );
-    my $e;
-    is(
-        $e = exception {
-            is( $response->content, $encoded_string, 'content is not decoded' );
-            is( $response->decoded_content,
-                $encoded_string, 'encoded_content is same as content here' );
-            is( $response->content_type, undef, 'no content type available' );
-            is_deeply( $response->content_type_params, [], 'no content type params' );
-        },
-        undef,
-        'All expected methods defined and not throwing exceptions'
-    ) or diag $e ;
+subtest 'No Defaults' => sub {
+    my $args_hash = {};
+
+    subtest 'No Hints' => sub {
+        my $response = HTTP::Tiny::UA::Response->new(
+            success  => 1,
+            protocol => 'HTTP/1.1',
+            status   => 200,
+            url      => 'synthetic://HTTP.Tiny.UA/300_decode_content.t',
+            content  => $encoded_string,
+            headers  => {},
+        );
+        my $e;
+        is(
+            $e = exception {
+                is( $response->content, $encoded_string, 'content is not decoded' );
+                is( $response->decoded_content($args_hash),
+                    $encoded_string, 'encoded_content is same as content here' );
+                is( $response->content_type, undef, 'no content type available' );
+                is_deeply( $response->content_type_params, [], 'no content type params' );
+            },
+            undef,
+            'All expected methods defined and not throwing exceptions'
+        ) or diag $e ;
+    };
+
+    subtest 'simple text/plain, No Hints' => sub {
+        my $response = HTTP::Tiny::UA::Response->new(
+            success  => 1,
+            protocol => 'HTTP/1.1',
+            status   => 200,
+            url      => 'synthetic://HTTP.Tiny.UA/300_decode_content.t',
+            content  => $encoded_string,
+            headers  => { 'content-type' => 'text/plain', }
+        );
+        my $e;
+        is(
+            $e = exception {
+
+                is( $response->content, $encoded_string, 'content is not decoded' );
+                is( $response->decoded_content($args_hash),
+                    $encoded_string, 'encoded_content is  the same as content here' );
+                is( $response->content_type, 'text/plain', 'content type is text/plain' );
+                is_deeply( $response->content_type_params, [], 'no content type params' );
+
+            },
+            undef,
+            'All expected methods defined and not throwing exceptions'
+        ) or diag $e;
+    };
+
+    subtest 'text/plain;charset=utf-8' => sub {
+        my $response = HTTP::Tiny::UA::Response->new(
+            success  => 1,
+            protocol => 'HTTP/1.1',
+            status   => 200,
+            url      => 'synthetic://HTTP.Tiny.UA/300_decode_content.t',
+            content  => $encoded_string,
+            headers  => { 'content-type' => 'text/plain;charset=utf-8', },
+        );
+        my $e;
+        is(
+            $e = exception {
+                is( $response->content, $encoded_string, 'content is not decoded' );
+                is( $response->decoded_content($args_hash),
+                    $utf8_string, 'encoded_content decoded as utf8' );
+                is( $response->content_type, 'text/plain', 'content type is text/plain' );
+                is_deeply( $response->content_type_params,
+                    ['charset=utf-8'], 'content type params says charset=utf8' );
+            },
+            undef,
+            'All expected methods defined and not throwing exceptions'
+        ) or diag $e;
+    };
+
 };
 
-subtest 'simple text/plain, No Hints' => sub {
-    my $response = HTTP::Tiny::UA::Response->new(
-        success  => 1,
-        protocol => 'HTTP/1.1',
-        status   => 200,
-        url      => 'synthetic://HTTP.Tiny.UA/300_decode_content.t',
-        content  => $encoded_string,
-        headers  => { 'content-type' => 'text/plain', }
-    );
-    my $e;
-    is(
-        $e = exception {
+subtest 'Default = utf-8' => sub {
 
-            is( $response->content, $encoded_string, 'content is not decoded' );
-            is( $response->decoded_content,
-                $encoded_string, 'encoded_content is  the same as content here' );
-            is( $response->content_type, 'text/plain', 'content type is text/plain' );
-            is_deeply( $response->content_type_params, [], 'no content type params' );
+    my $args_hash = { encoding => 'utf-8' };
 
-        },
-        undef,
-        'All expected methods defined and not throwing exceptions'
-    ) or diag $e;
+    subtest 'No Hints' => sub {
+        my $response = HTTP::Tiny::UA::Response->new(
+            success  => 1,
+            protocol => 'HTTP/1.1',
+            status   => 200,
+            url      => 'synthetic://HTTP.Tiny.UA/300_decode_content.t',
+            content  => $encoded_string,
+            headers  => {},
+        );
+        my $e;
+        is(
+            $e = exception {
+                is( $response->content, $encoded_string, 'content is not decoded' );
+                is( $response->decoded_content($args_hash),
+                    $utf8_string, 'decoded_content decodes as utf8' );
+                is( $response->content_type, undef, 'no content type available' );
+                is_deeply( $response->content_type_params, [], 'no content type params' );
+            },
+            undef,
+            'All expected methods defined and not throwing exceptions'
+        ) or diag $e ;
+    };
+
+    subtest 'simple text/plain, No Hints' => sub {
+        my $response = HTTP::Tiny::UA::Response->new(
+            success  => 1,
+            protocol => 'HTTP/1.1',
+            status   => 200,
+            url      => 'synthetic://HTTP.Tiny.UA/300_decode_content.t',
+            content  => $encoded_string,
+            headers  => { 'content-type' => 'text/plain', }
+        );
+        my $e;
+        is(
+            $e = exception {
+
+                is( $response->content, $encoded_string, 'content is not decoded' );
+                is( $response->decoded_content($args_hash),
+                    $utf8_string, 'decoded_content decodes as utf8' );
+                is( $response->content_type, 'text/plain', 'content type is text/plain' );
+                is_deeply( $response->content_type_params, [], 'no content type params' );
+
+            },
+            undef,
+            'All expected methods defined and not throwing exceptions'
+        ) or diag $e;
+    };
+
+    subtest 'text/plain;charset=utf-8' => sub {
+        my $response = HTTP::Tiny::UA::Response->new(
+            success  => 1,
+            protocol => 'HTTP/1.1',
+            status   => 200,
+            url      => 'synthetic://HTTP.Tiny.UA/300_decode_content.t',
+            content  => $encoded_string,
+            headers  => { 'content-type' => 'text/plain;charset=utf-8', },
+        );
+        my $e;
+        is(
+            $e = exception {
+                is( $response->content, $encoded_string, 'content is not decoded' );
+                is( $response->decoded_content($args_hash),
+                    $utf8_string, 'decoded_content decodes as utf8' );
+                is( $response->content_type, 'text/plain', 'content type is text/plain' );
+                is_deeply( $response->content_type_params,
+                    ['charset=utf-8'], 'content type params says charset=utf8' );
+            },
+            undef,
+            'All expected methods defined and not throwing exceptions'
+        ) or diag $e;
+    };
+
 };
 
-subtest 'text/plain;charset=utf-8' => sub {
-    my $response = HTTP::Tiny::UA::Response->new(
-        success  => 1,
-        protocol => 'HTTP/1.1',
-        status   => 200,
-        url      => 'synthetic://HTTP.Tiny.UA/300_decode_content.t',
-        content  => $encoded_string,
-        headers  => { 'content-type' => 'text/plain;charset=utf-8', },
-    );
-    my $e;
-    is(
-        $e = exception {
-            is( $response->content,         $encoded_string, 'content is not decoded' );
-            is( $response->decoded_content, $utf8_string,    'encoded_content decoded as utf8' );
-            is( $response->content_type,    'text/plain',    'content type is text/plain' );
-            is_deeply( $response->content_type_params,
-                ['charset=utf-8'], 'content type params says charset=utf8' );
-        },
-        undef,
-        'All expected methods defined and not throwing exceptions'
-    ) or diag $e;
+subtest 'Default = utf-8 + force ' => sub {
+
+    my $args_hash = { encoding => 'utf-8', force => 1 };
+
+    subtest 'No Hints' => sub {
+        my $response = HTTP::Tiny::UA::Response->new(
+            success  => 1,
+            protocol => 'HTTP/1.1',
+            status   => 200,
+            url      => 'synthetic://HTTP.Tiny.UA/300_decode_content.t',
+            content  => $encoded_string,
+            headers  => {},
+        );
+        my $e;
+        is(
+            $e = exception {
+                is( $response->content, $encoded_string, 'content is not decoded' );
+                is( $response->decoded_content($args_hash),
+                    $utf8_string, 'decoded_content decodes as utf8' );
+                is( $response->content_type, undef, 'no content type available' );
+                is_deeply( $response->content_type_params, [], 'no content type params' );
+            },
+            undef,
+            'All expected methods defined and not throwing exceptions'
+        ) or diag $e ;
+    };
+
+    subtest 'simple text/plain, No Hints' => sub {
+        my $response = HTTP::Tiny::UA::Response->new(
+            success  => 1,
+            protocol => 'HTTP/1.1',
+            status   => 200,
+            url      => 'synthetic://HTTP.Tiny.UA/300_decode_content.t',
+            content  => $encoded_string,
+            headers  => { 'content-type' => 'text/plain', }
+        );
+        my $e;
+        is(
+            $e = exception {
+
+                is( $response->content, $encoded_string, 'content is not decoded' );
+                is( $response->decoded_content($args_hash),
+                    $utf8_string, 'decoded_content decodes as utf8' );
+                is( $response->content_type, 'text/plain', 'content type is text/plain' );
+                is_deeply( $response->content_type_params, [], 'no content type params' );
+
+            },
+            undef,
+            'All expected methods defined and not throwing exceptions'
+        ) or diag $e;
+    };
+
+    subtest 'text/plain;charset=utf-8' => sub {
+        my $response = HTTP::Tiny::UA::Response->new(
+            success  => 1,
+            protocol => 'HTTP/1.1',
+            status   => 200,
+            url      => 'synthetic://HTTP.Tiny.UA/300_decode_content.t',
+            content  => $encoded_string,
+            headers  => { 'content-type' => 'text/plain;charset=utf-8', },
+        );
+        my $e;
+        is(
+            $e = exception {
+                is( $response->content, $encoded_string, 'content is not decoded' );
+                is( $response->decoded_content($args_hash),
+                    $utf8_string, 'decoded_content decodes as utf8' );
+                is( $response->content_type, 'text/plain', 'content type is text/plain' );
+                is_deeply( $response->content_type_params,
+                    ['charset=utf-8'], 'content type params says charset=utf8' );
+            },
+            undef,
+            'All expected methods defined and not throwing exceptions'
+        ) or diag $e;
+    };
+
+};
+
+subtest 'Default = undef + force ' => sub {
+
+    my $args_hash = { encoding => undef, force => 1 };
+
+    subtest 'No Hints' => sub {
+        my $response = HTTP::Tiny::UA::Response->new(
+            success  => 1,
+            protocol => 'HTTP/1.1',
+            status   => 200,
+            url      => 'synthetic://HTTP.Tiny.UA/300_decode_content.t',
+            content  => $encoded_string,
+            headers  => {},
+        );
+        my $e;
+        is(
+            $e = exception {
+                is( $response->content, $encoded_string, 'content is not decoded' );
+                is( $response->decoded_content($args_hash),
+                    $encoded_string, 'decoded_content does not decode' );
+                is( $response->content_type, undef, 'no content type available' );
+                is_deeply( $response->content_type_params, [], 'no content type params' );
+            },
+            undef,
+            'All expected methods defined and not throwing exceptions'
+        ) or diag $e ;
+    };
+
+    subtest 'simple text/plain, No Hints' => sub {
+        my $response = HTTP::Tiny::UA::Response->new(
+            success  => 1,
+            protocol => 'HTTP/1.1',
+            status   => 200,
+            url      => 'synthetic://HTTP.Tiny.UA/300_decode_content.t',
+            content  => $encoded_string,
+            headers  => { 'content-type' => 'text/plain', }
+        );
+        my $e;
+        is(
+            $e = exception {
+
+                is( $response->content, $encoded_string, 'content is not decoded' );
+                is( $response->decoded_content($args_hash),
+                    $encoded_string, 'decoded_content does not decode' );
+                is( $response->content_type, 'text/plain', 'content type is text/plain' );
+                is_deeply( $response->content_type_params, [], 'no content type params' );
+
+            },
+            undef,
+            'All expected methods defined and not throwing exceptions'
+        ) or diag $e;
+    };
+
+    subtest 'text/plain;charset=utf-8' => sub {
+        my $response = HTTP::Tiny::UA::Response->new(
+            success  => 1,
+            protocol => 'HTTP/1.1',
+            status   => 200,
+            url      => 'synthetic://HTTP.Tiny.UA/300_decode_content.t',
+            content  => $encoded_string,
+            headers  => { 'content-type' => 'text/plain;charset=utf-8', },
+        );
+        my $e;
+        is(
+            $e = exception {
+                is( $response->content, $encoded_string, 'content is not decoded' );
+                is( $response->decoded_content($args_hash),
+                    $encoded_string, 'decoded_content does not decode' );
+                is( $response->content_type, 'text/plain', 'content type is text/plain' );
+                is_deeply( $response->content_type_params,
+                    ['charset=utf-8'], 'content type params says charset=utf8' );
+            },
+            undef,
+            'All expected methods defined and not throwing exceptions'
+        ) or diag $e;
+    };
+
 };
 
 done_testing;


### PR DESCRIPTION
```perl
  ->decoded_content(?forced_contenttype) => scalar
  ->content_type()   => scalar or undef
  ->content_type_params => arrayref
```
decoded_content optionally takes a encoding field that overrides
autodetection logic and ultimately serves as a shorthand that means
```perl
  ->decoded_content('utf-8')
```
Yields
```perl
  Encode::decode('utf-8', $result->content, Encode::FB_CROAK );
```
Removal of this optional parameter will revert to using content_type and
content_type_params to determine the decoding:

  1. If there is no content-type, there is no decoding.
  2. If the content type is not text/* , there is no decoding.
  3. If the content type contains no parameters after a ';' , there is
     no decoding.
  4. If a parameter in the parameter list matches `charset=(.*)`, $1 is
     picked as an encoding.
  5. If there are multiple such parameters, the rightmost one takes
     precedence.
  6. If there is no such parameter, there is no encoding.

The design of the above is also designed to make it easy for people who
are working with content-types that don't qualify as "text" as per
IANA/W3C, and may have non-standard parameters that are also not
supported in the spec.

For instance, myself, I'm dealing with some upstream declaring
'application/json;charset=utf-8', and I could potentially map that
locally now as:
```perl
  if ( $result->content_type eq 'application/json' ) {
    my $charset = 'utf-8'; # Spec says to assume utf8 anyway
    for my $param (@{ $result->content_params }) {
      if ( $param =~ /^charset=(.*)$/ ) {
        $charset = $1;
      }
    }
    return $json->decode( $result->decoded_content( $charset ) );
  }
```
And that would theoretically work if upstream went insane and changed
'=utf-8' to '=iso-8859-15'.