### PR TITLE
Use HTTP::Tiny::UA in the docs, not HTTP::Tiny

### DIFF
--- a/lib/HTTP/Tiny/UA/Response.pm
+++ b/lib/HTTP/Tiny/UA/Response.pm
@@ -71,7 +71,7 @@ sub header {
 
 =head1 SYNOPSIS
 
-    my $res = HTTP::Tiny->new->get( $url );
+    my $res = HTTP::Tiny::UA->new->get( $url );
 
     if ( $res->success ) {
         say "Got " . $res->header("Content-Length") . " bytes";


### PR DESCRIPTION
At least that's how I presume it's supposed to work.
